### PR TITLE
update version to 0.0.2

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Spock",
   "description": "A Grunt Gui Tool",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "app/app.html",
   "single-instance": true,
   "window": {


### PR DESCRIPTION
From now on, Spock supports OS X

Bug fixes:
1. Can't drag on OS X
2. Fault-tolerant
3. Project Delete Bug 
